### PR TITLE
Move the contribution to the test view instead of the explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
       }
     ],
     "views": {
-      "explorer": [
+      "test": [
         {
           "id": "mocha",
           "name": "mocha",


### PR DESCRIPTION
The April update of VSCode introduced the feature to add custom views to another view in the Activity Bar which was actually [highlighted in the patch notes using this extension](https://code.visualstudio.com/updates/v1_23#_contributions-to-the-activity-bar). I have adapted the `package.json` file to enable this feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maty21/mocha-sidebar/97)
<!-- Reviewable:end -->
