### PR TITLE
add config showErrorPopup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Under File > Preferences > Workspace Settings, you can configure [Mocha options]
 //Mocha: run tests on each save
 "mocha.runTestsOnSave": "false",
 
+// show popup when error
+"mocha.showErrorPopup": true,
+
 // Mocha: Environment variables to run your tests
 "mocha.env": {},
 
@@ -173,14 +176,14 @@ To quickly run tests, you can create a keyboard shortcut under File > Preference
 
 Following commands are also supported:
 
-| Command | Title |
-|---------|-------------|
-| `mocha.runAllTests` | Mocha: Run all tests |
-| `mocha.runFailedTests` | Mocha: Run failed tests |
-| `mocha.runLastSetAgain` | Mocha: Run last set again |
-| `mocha.runTestAtCursor` | Mocha: Run tests matching the current cursor position or the current active file |
-| `mocha.runTestsByPattern` | Mocha: Run tests matching a pattern |
-| `mocha.selectAndRunTest` | Mocha: Select and run a test |
+| Command                   | Title                                                                            |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| `mocha.runAllTests`       | Mocha: Run all tests                                                             |
+| `mocha.runFailedTests`    | Mocha: Run failed tests                                                          |
+| `mocha.runLastSetAgain`   | Mocha: Run last set again                                                        |
+| `mocha.runTestAtCursor`   | Mocha: Run tests matching the current cursor position or the current active file |
+| `mocha.runTestsByPattern` | Mocha: Run tests matching a pattern                                              |
+| `mocha.selectAndRunTest`  | Mocha: Select and run a test                                                     |
 
 
 ### How it works

--- a/config.js
+++ b/config.js
@@ -19,3 +19,4 @@ exports.requires = () => {
   return files.map(s => s.toString());
 };
 exports.sideBarOptions = () => getConfiguration().sideBarOptions;
+exports.showErrorPopup = () => getConfiguration().showErrorPopup;

--- a/mochashim.js
+++ b/mochashim.js
@@ -119,7 +119,8 @@ function forkWorker(workerPath, argsObject, rootPath) {
 function handleError(err, reject) {
   const qa = 'Q/A';
   const gitter = 'Gitter';
-  vscode.window.showErrorMessage(`Failed to run Mocha due to error message:( ${err.message}) .
+  if (config.showErrorPopup) {
+    vscode.window.showErrorMessage(`Failed to run Mocha due to error message:( ${err.message}) .
   error trace can be found in the ouput channel .
     for more help:`,qa,gitter).then(val=>{
     switch (val) {
@@ -132,7 +133,8 @@ function handleError(err, reject) {
       // default:
       // vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('https://github.com/maty21/mocha-sidebar'))
     }
-  });
+    });
+  }
   outputChannel.appendLine(err.stack);
   outputChannel.show();
   reject(err);

--- a/package.json
+++ b/package.json
@@ -258,6 +258,11 @@
           "default": {},
           "description": "Mocha: Options to run Mocha"
         },
+        "mocha.showErrorPopup": {
+          "default": "true",
+          "description": "Show popup when having any error while executing test",
+          "type": "boolean"
+        },
         "mocha.showInExplorer": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
hi all

I am using vscode with mocha-sidebar for now and I am really dont like the way we handle error. For example, for any mistaken when you typing code (especially with TS), func `handleError` will be triggered and show popup which is very annoyed. 

I add config `showErrorPopup` to help all of us control that popup. The log will still be appended into Output panel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maty21/mocha-sidebar/105)
<!-- Reviewable:end -->
