### PR TITLE
Fixed upper/lowercase path issue

### DIFF
--- a/lib/coverage/code-coverage.js
+++ b/lib/coverage/code-coverage.js
@@ -44,7 +44,7 @@ class codeCoverage {
   }
 
   getResultByPath(path) {
-    return this.coverageResult[path];
+    return this.coverageResult[path.toLowerCase()];
   }
 
   updateDecorationByFile() {
@@ -249,7 +249,7 @@ class codeCoverage {
           reject(err)
         }
         else {
-          data.forEach(result => this.coverageResult[result.file] = result)
+          data.forEach(result => this.coverageResult[result.file.toLowerCase()] = result)
           resolve();
         }
       })


### PR DESCRIPTION
Fixed an issue, where different cases of drive letters lead to an issue not finding results in the lcov.info.

EG:
filepath inside lcov.info "c:/test/testfile.js",
but filepath usesd by vscode is "C:/test/testfile.js"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maty21/mocha-sidebar/149)
<!-- Reviewable:end -->
