### PR TITLE
feat: run tests in parallel and show realtime results

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,6 +11,7 @@ exports.runTestsOnSave = () => getConfiguration().runTestsOnSave;
 exports.options = () => getConfiguration().options;
 exports.node_options = () => getConfiguration().node_options;
 exports.files = () => getConfiguration().files;
+exports.parallelTests = () => getConfiguration().parallelTests;
 exports.subdirectory = () => getConfiguration().subdirectory;
 exports.setSubdirectory = (subdirectory)=>getConfiguration().update('subdirectory',subdirectory);
 exports.requires = () => {

--- a/package.json
+++ b/package.json
@@ -318,6 +318,11 @@
                     "description": "Mocha: mocha package path then the sideBar installed one for example ../node_modules/mocha",
                     "type": "boolean"
                 },
+                "mocha.parallelTests": {
+                    "default": 5,
+                    "description": "Mocha: number of tests to run in parallel",
+                    "type": "number"
+                },
                 "mocha.files.glob": {
                     "default": "test/**/*.js",
                     "description": "Mocha: Glob to search for test files",
@@ -375,6 +380,7 @@
         "vscode": "0.11.x"
     },
     "dependencies": {
+        "async": "^2.6.1",
         "await-done": "^1.0.1",
         "babel-register": "^6.26.0",
         "babylon": "^6.13.1",

--- a/provider-extensions/consts.js
+++ b/provider-extensions/consts.js
@@ -2,7 +2,8 @@ let consts = {
 
     PASSED: 'passed',
     FAILED: 'failed',
-    NOT_RUN: 'notRun'
+    NOT_RUN: 'notRun',
+    RUNNING: 'running'
 
 }
 


### PR DESCRIPTION
This change makes it so that tests can run in parallel.  The amount of tests that can run simultaneously is set by mocha.parallelTests (default of 5).  Tests in the sidebar change their icon when running and then show the result when finished.
![kapture 2018-12-02 at 18 22 36](https://user-images.githubusercontent.com/3375326/49346419-49c8f480-f660-11e8-99db-65528fd0021c.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maty21/mocha-sidebar/162)
<!-- Reviewable:end -->
