### PR TITLE
Passing mocha environment settings to coverage processes

### DIFF
--- a/lib/coverage/code-coverage.js
+++ b/lib/coverage/code-coverage.js
@@ -23,6 +23,7 @@ class codeCoverage {
     this._pathToNyc = join(__dirname, '../../node_modules/nyc/bin/nyc.js');// or configuration 
     this._command = (platform() === 'win32' ? 'cmd.exe' : 'sh');
     this._args = (platform() === 'win32' ? ['/s', '/c'] : ['-c']);
+    this._env = Object.assign({}, config.env());
     this._cmd = this._commandBuilder();
     this._coveragePath = join(this._workDir, './coverage')
     this.coverageResult = {};
@@ -86,7 +87,8 @@ class codeCoverage {
      
       const cp = fork(this._pathToNyc, this._cmd, {
         cwd: this._workDir,
-        silent: true 
+        silent: true,
+        env: this._env
         // stdio: 'inherit',
       });
       cp.on('message', (m) => {
@@ -128,7 +130,8 @@ class codeCoverage {
       }
       this._cmd = this._commandBuilder();
       const cp = spawn(path,config.node_options().concat([this._cmd]), {
-        cwd: this._workDir
+        cwd: this._workDir,
+        env: this._env
         // stdio: 'inherit',
       });
 


### PR DESCRIPTION
This will mimic the environment behavior from the test runner processes to help support dependency configuration such as ts-node.