### PR TITLE
avoiding 'undefined' .document errors that flood the log file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -28,7 +28,7 @@ const mochaPath = (refresh = false) => {
         //const mochaSuffix = "/bin/mocha";
         return (mochaLocation = { require: path.join(baseMochaFolder, "index.js"), binary: path.join(baseMochaFolder, "/bin/_mocha") });
       } catch (error) {
-        messages.send(messages.channelName.TEST, `ccant find mocha locally and there is no setting for other path,${error}`);
+        messages.send(messages.channelName.TEST, `cannot find mocha locally and there is no setting for other path,${error}`);
       }
       return (mochaLocation = { require: "mocha", binary: "mocha" });
     }

--- a/lib/coverage/code-coverage.js
+++ b/lib/coverage/code-coverage.js
@@ -46,6 +46,10 @@ class codeCoverage {
   updateDecorationByFile() {
     clearData();
     // var CURSOR_FOREGROUND1 = new vscode.ThemeColor('editor.background')
+    if (!vscode.window.activeTextEditor) {
+      // there is no active text editor, perhaps a Webview is active
+      return;
+    }
     const { fileName } = vscode.window.activeTextEditor.document;
     if (this._toggleCoverage) {
       const resForFileName = this.getResultByPath(fileName);

--- a/lib/provider-extensions/decorationProvider.js
+++ b/lib/provider-extensions/decorationProvider.js
@@ -17,9 +17,17 @@ class decorationProvider {
     const tests = await core.getTests();
     this.initDecorationStyle(tests);
     //core.on(core.events.INIT_RESULTS, () => this.removeStyle())
-    notification.on(notification.events.FILE_CHANGED, editor => this.reloadStyleByPath(editor.document.fileName));
+    notification.on(notification.events.FILE_CHANGED, editor => {
+      if (editor) {
+        this.reloadStyleByPath(editor.document.fileName);
+      }
+    });
     // maybe could cause over rendring issue fixing
-    notification.on(notification.events.CONTENT_CHANGED, editor => this.reloadStyleByPath(editor.document.fileName));
+    notification.on(notification.events.CONTENT_CHANGED, editor => {
+      if (editor) {
+        this.reloadStyleByPath(editor.document.fileName);
+      }
+    });
     //core.on(core.events.TESTS, tests => this.updateDecorationStyle(tests));
     core.on(core.events.FINISH_RESULTS_AGGREGATED, results => (this.currentResults = results));
     core.on(core.events.UPDATE_RESULT, result => this.setDecorationOnUpdateResults(result));
@@ -98,7 +106,9 @@ class decorationProvider {
         this.currentResults.results.passed.filter(p => p.file === file).forEach(r => this.reloadDecorationByName(consts.PASSED, r));
         this.currentResults.results.failed.filter(p => p.file === file).forEach(r => this.reloadDecorationByName(consts.FAILED, r));
       }
-      this.currentResults.notRunTests.filter(p => p.file === file).forEach(t => this.reloadDecorationByName(consts.NOT_RUN, t));
+      if (this.currentResults.notRunTests) {
+        this.currentResults.notRunTests.filter(p => p.file === file).forEach(t => this.reloadDecorationByName(consts.NOT_RUN, t));
+      }
       // resultsForPath.forEach(r => this.removeSpecificStyle(r.fullName));
     }
   }

--- a/lib/provider-extensions/mochaLens.js
+++ b/lib/provider-extensions/mochaLens.js
@@ -101,6 +101,7 @@ class mochaLens extends abstractCodeLens {
   }
   notificationRegister() {
     this.notification.on(this.notification.events.CONTENT_CHANGED, async editor => {
+      if (!editor || !this.tests) { return; }
       const tests = this.tests.find(test => test.file === editor.document.fileName);
       if (tests) {
         core.updateLines(editor.document.fileName, editor.document.getText());

--- a/lib/provider-extensions/runDebug.js
+++ b/lib/provider-extensions/runDebug.js
@@ -105,6 +105,10 @@ class debuggerProvider {
     return mochaTest;
   }
   getDebugFromSettings() {
+    if (!vscode.window.activeTextEditor) {
+      messages.send(messages.channelName.TEST, `no active editor!`);
+      return null;
+    }
     const launchArray = vscode.workspace.getConfiguration("launch", vscode.window.activeTextEditor.document.uri);
     const debugSetting = launchArray.configurations.find(s => s.name === config.debugSettingsName());
     if (!debugSetting) {


### PR DESCRIPTION
Checks for `undefined` active editor or other structures that are causing errors to flood the console log. 

Whenever a VS Code WebView is focused, the `vscode.window.activeTextEditor` is undefined causing the coverage code to throw errors. This floods the console log and makes it hard to find the errors people actually want to debug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maty21/mocha-sidebar/208)
<!-- Reviewable:end -->
