### PR TITLE
fix logVerbose documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
                 },
                 "mocha.logVerbose": {
                     "default": true,
-                    "description": "Mocha: mocha package path then the sideBar installed one for example ../node_modules/mocha",
+                    "description": "Mocha: set log level to verbose",
                     "type": "boolean"
                 },
                 "mocha.parallelTests": {


### PR DESCRIPTION
# Problem
Documentation had the wrong description for logVerbose option
![Capture d’écran du 2021-03-19 11-27-30](https://user-images.githubusercontent.com/560852/111767323-e140c880-88a6-11eb-8115-10b506db9881.png)

# Solution
fix description by replacing it by : `"Mocha: set log level to verbose"`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maty21/mocha-sidebar/259)
<!-- Reviewable:end -->
